### PR TITLE
Feature/view institution in asesor

### DIFF
--- a/src/app/dashboard/asesor/page.tsx
+++ b/src/app/dashboard/asesor/page.tsx
@@ -1,16 +1,15 @@
-import InstitutionAsesor from "@/modules/asesor/templates/institution-asesor";
-import { getClientInfoByIdService } from "@/modules/dashboard/services";
-import { getInstitutionService } from "@/modules/institution/services";
-import { getPhotoUserService } from "@/modules/settings/services";
+import InstitutionAsesor from '@/modules/asesor/templates/institution-asesor';
+import {getClientInfoByIdService} from '@/modules/dashboard/services';
+import {getInstitutionService} from '@/modules/institution/services';
+import {getPhotoUserService} from '@/modules/settings/services';
 
 export default async function Page() {
   const institution = await getInstitutionService();
   if (!institution) return <></>;
   const asesor = await getClientInfoByIdService(institution.asesorId);
   const photo = await getPhotoUserService(institution.asesorId);
-  if(!asesor?.data || !photo) return <></>;
+  if (!asesor?.data || !photo) return <></>;
   asesor.data.photo = photo;
 
-  return <InstitutionAsesor id={institution.id} data={asesor.data!}/>;
+  return <InstitutionAsesor id={institution.id} data={asesor.data!} />;
 }
-

--- a/src/app/dashboard/institutions/page.tsx
+++ b/src/app/dashboard/institutions/page.tsx
@@ -1,4 +1,7 @@
-import {getInstitutionByAsesorService} from '@/modules/institution/services';
+import {
+  getClientByInstitutionService,
+  getInstitutionByAsesorService,
+} from '@/modules/institution/services';
 import AsesorInstitution from '@/modules/institution/templates/asesor-institution';
 import {getPhotoUserService} from '@/modules/settings/services';
 
@@ -9,7 +12,13 @@ export default async function Page() {
 
   const institutionsWithPhotos = await Promise.all(
     asesor.map(async institution => {
-      const photo = await getPhotoUserService(institution.id);
+      const client = await getClientByInstitutionService(institution.id);
+
+      if (client === null) {
+        return {...institution, photo: null};
+      }
+
+      const photo = await getPhotoUserService(client);
       return {...institution, photo};
     })
   );

--- a/src/app/dashboard/institutions/page.tsx
+++ b/src/app/dashboard/institutions/page.tsx
@@ -1,3 +1,10 @@
-export default function Page() {
-  return <div>Institutiones</div>;
+import {getInstitutionByAsesorService} from '@/modules/institution/services';
+import AsesorInstitution from '@/modules/institution/templates/asesor-institution';
+
+export default async function Page() {
+  const asesor = await getInstitutionByAsesorService();
+
+  if (!Array.isArray(asesor) || asesor.length === 0) return <p>No institutions found</p>;
+
+  return <AsesorInstitution institutions={asesor} />;
 }

--- a/src/app/dashboard/institutions/page.tsx
+++ b/src/app/dashboard/institutions/page.tsx
@@ -1,10 +1,18 @@
 import {getInstitutionByAsesorService} from '@/modules/institution/services';
 import AsesorInstitution from '@/modules/institution/templates/asesor-institution';
+import {getPhotoUserService} from '@/modules/settings/services';
 
 export default async function Page() {
   const asesor = await getInstitutionByAsesorService();
 
   if (!Array.isArray(asesor) || asesor.length === 0) return <p>No institutions found</p>;
 
-  return <AsesorInstitution institutions={asesor} />;
+  const institutionsWithPhotos = await Promise.all(
+    asesor.map(async institution => {
+      const photo = await getPhotoUserService(institution.id);
+      return {...institution, photo};
+    })
+  );
+
+  return <AsesorInstitution institutions={institutionsWithPhotos} />;
 }

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,31 +1,31 @@
-import { SignOut } from '@/modules/auth/components/sign-out';
-import { getClientInfoByTokenService } from '@/modules/dashboard/services';
-import { SideBar } from '@/modules/dashboard/templates/sidebar';
-import { TopBar } from '@/modules/dashboard/templates/topbar';
-import { getPhotoUserService } from '@/modules/settings/services';
+import {SignOut} from '@/modules/auth/components/sign-out';
+import {getClientInfoByTokenService} from '@/modules/dashboard/services';
+import {SideBar} from '@/modules/dashboard/templates/sidebar';
+import {TopBar} from '@/modules/dashboard/templates/topbar';
+import {getPhotoUserService} from '@/modules/settings/services';
 
 export default async function RootLayout({
-    children,
+  children,
 }: Readonly<{
-    children: React.ReactNode;
+  children: React.ReactNode;
 }>) {
-    const clientInfo = (await getClientInfoByTokenService()).data;
+  const clientInfo = (await getClientInfoByTokenService()).data;
 
-    if (!clientInfo) {
-        return <SignOut />;
-    }
-    if (clientInfo.photo) {
-        const photo = await getPhotoUserService(clientInfo.id);
-        if (photo) clientInfo.photo = photo;
-    }
+  if (!clientInfo) {
+    return <SignOut />;
+  }
+  if (clientInfo.photo) {
+    const photo = await getPhotoUserService(clientInfo.id);
+    if (photo) clientInfo.photo = photo;
+  }
 
-    return (
-        <section className="flex flex-row h-screen w-screen overflow-hidden">
-            <SideBar clientInfo={clientInfo} />
-            <div className="flex h-full w-full flex-col bg-gray-100 gap-8 md:gap-0">
-                <TopBar clientInfo={clientInfo} />
-                <div className="w-full max-w-full h-full rounded-md overflow-hidden">{children}</div>
-            </div>
-        </section>
-    );
+  return (
+    <section className="flex flex-row h-screen w-screen overflow-hidden">
+      <SideBar clientInfo={clientInfo} />
+      <div className="flex h-full w-full flex-col bg-gray-100 gap-8 md:gap-0">
+        <TopBar clientInfo={clientInfo} />
+        <div className="w-full max-w-full h-full rounded-md overflow-hidden">{children}</div>
+      </div>
+    </section>
+  );
 }

--- a/src/modules/common/services/index.tsx
+++ b/src/modules/common/services/index.tsx
@@ -1,105 +1,126 @@
-import { auth } from '@/auth';
+import {auth} from '@/auth';
 
 export async function apiGet<T>(path: string): Promise<T | null> {
-    try {
-        const response = await fetch(`${process.env.API_URL}${path}`);
-        return await response.json();
-    } catch (e) {
-        return null;
-    }
+  try {
+    const response = await fetch(`${process.env.API_URL}${path}`);
+    return await response.json();
+  } catch (e) {
+    return null;
+  }
 }
 
 export async function apiPost<T>(path: string, body: {}): Promise<T | null> {
-    try {
-        const response = await fetch(`${process.env.API_URL}${path}`, {
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            method: 'POST',
-            body: JSON.stringify(body),
-        });
+  try {
+    const response = await fetch(`${process.env.API_URL}${path}`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+      body: JSON.stringify(body),
+    });
 
-        if (!response.ok) {
-            console.error('Response failed');
-            return null;
-        }
-        return await response.json();
-    } catch (e) {
-        console.error('Error:', e);
-        return null;
+    if (!response.ok) {
+      console.error('Response failed');
+      return null;
     }
+    return await response.json();
+  } catch (e) {
+    console.error('Error:', e);
+    return null;
+  }
 }
 
 export async function apiSecureGet<T>(path: string): Promise<T | null> {
-    const session = await auth();
-    try {
-        const response = await fetch(`${process.env.API_URL}${path}`, {
-            headers: {
-                Authorization: `Bearer ${session?.user.token}`,
-            },
-        });
-        return await response.json();
-    } catch (e) {
-        console.error(e);
-        return null;
-    }
+  const session = await auth();
+  try {
+    const response = await fetch(`${process.env.API_URL}${path}`, {
+      headers: {
+        Authorization: `Bearer ${session?.user.token}`,
+      },
+    });
+    return await response.json();
+  } catch (e) {
+    console.error(e);
+    return null;
+  }
 }
 
 export async function apiSecurePost<T>(path: string, body: {} = {}): Promise<T | null> {
-    return await apiSecureMethod<T>(path, body, 'POST');
+  return await apiSecureMethod<T>(path, body, 'POST');
 }
 
 export async function apiSecurePut<T>(path: string, body: {} = {}): Promise<T | null> {
-    return await apiSecureMethod<T>(path, body, 'PUT');
+  return await apiSecureMethod<T>(path, body, 'PUT');
 }
 
 export async function apiSecureDelete<T>(path: string, body: {} = {}): Promise<T | null> {
-    return await apiSecureMethod<T>(path, body, 'DELETE');
+  return await apiSecureMethod<T>(path, body, 'DELETE');
 }
 
 async function apiSecureMethod<T>(
-    path: string,
-    body: {},
-    method: 'PUT' | 'POST' | 'DELETE'
+  path: string,
+  body: {},
+  method: 'PUT' | 'POST' | 'DELETE'
 ): Promise<T | null> {
-    const session = await auth();
-    try {
-        const response = await fetch(`${process.env.API_URL}${path}`, {
-            method: method,
-            headers: {
-                'Content-Type': 'application/json',
-                Authorization: `Bearer ${session?.user.token}`,
-            },
-            body: JSON.stringify(body),
-        });
-        if (!response.ok) {
-            console.error(await response.text());
-            return null;
-        }
-        return await response.json();
-    } catch (e) {
-        console.error('Error:', e);
-        return null;
+  const session = await auth();
+  try {
+    const response = await fetch(`${process.env.API_URL}${path}`, {
+      method: method,
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${session?.user.token}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+      console.error(await response.text());
+      return null;
     }
+    return await response.json();
+  } catch (e) {
+    console.error('Error:', e);
+    return null;
+  }
 }
 
 export async function apiSecureMethodPostFile<T>(path: string, body: FormData): Promise<T | null> {
-    const session = await auth();
-    try {
-        const response = await fetch(`${process.env.API_URL}${path}`, {
-            method: 'POST',
-            headers: {
-                Authorization: `Bearer ${session?.user.token}`,
-            },
-            body: body,
-        });
-        if (!response.ok) {
-            console.error('Response failed');
-            return null;
-        }
-        return await response.json();
-    } catch (e) {
-        console.error('Error:', e);
-        return null;
+  const session = await auth();
+  try {
+    const response = await fetch(`${process.env.API_URL}${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${session?.user.token}`,
+      },
+      body: body,
+    });
+    if (!response.ok) {
+      console.error('Response failed');
+      return null;
     }
+    return await response.json();
+  } catch (e) {
+    console.error('Error:', e);
+    return null;
+  }
+}
+
+export async function apiPut<T>(path: string, body: {}): Promise<T | null> {
+  try {
+    const response = await fetch(`${process.env.API_URL}${path}`, {
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'PUT',
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      console.error('Response failed');
+      return null;
+    }
+    return await response.json();
+  } catch (e) {
+    console.error('Error:', e);
+    return null;
+  }
 }

--- a/src/modules/dashboard/components/routes-sidebar/index.tsx
+++ b/src/modules/dashboard/components/routes-sidebar/index.tsx
@@ -1,35 +1,35 @@
 import Link from 'next/link';
-import { ROUTES_SIDEBAR, Route } from '../../types';
-import { ROLES } from '@/modules/auth/types/enum';
+import {ROUTES_SIDEBAR, Route} from '../../types';
+import {ROLES} from '@/modules/auth/types/enum';
 
 type RoutesSidebarProps = {
-    routes: Route[];
-    path: string;
-    rol: ROLES;
+  routes: Route[];
+  path: string;
+  rol: ROLES;
 };
 
 export function RoutesSidebar(props: RoutesSidebarProps) {
-    const path = (routePath: string): Boolean => {
-        if (props.path === routePath) return true;
+  const path = (routePath: string): Boolean => {
+    if (props.path === routePath) return true;
 
-        const routePathSplit = routePath.split(ROUTES_SIDEBAR.DASHBOARD).join('');
-        return Boolean(routePathSplit) && props.path.includes(routePathSplit);
-    };
-    return (
-        <div className="flex flex-col gap-2">
-            {props.routes.map(route => (
-                <>
-                    {(route.role === 'all' || route.role === props.rol) && (
-                        <Link
-                            href={route.route}
-                            className={`flex p-[10px] flex-row gap-x-4 ${path(route.route) && 'bg-gray-100'} items-center rounded-md `}
-                        >
-                            {route.icon}
-                            <span className="text-sm">{route.name}</span>
-                        </Link>
-                    )}
-                </>
-            ))}
-        </div>
-    );
+    const routePathSplit = routePath.split(ROUTES_SIDEBAR.DASHBOARD).join('');
+    return Boolean(routePathSplit) && props.path.includes(routePathSplit);
+  };
+  return (
+    <div className="flex flex-col gap-2">
+      {props.routes.map(route => (
+        <>
+          {(route.role === 'all' || route.role === props.rol) && (
+            <Link
+              href={route.route}
+              className={`flex p-[10px] flex-row gap-x-4 ${path(route.route) && 'bg-gray-100'} items-center rounded-md `}
+            >
+              {route.icon}
+              <span className="text-sm">{route.name}</span>
+            </Link>
+          )}
+        </>
+      ))}
+    </div>
+  );
 }

--- a/src/modules/dashboard/types/index.tsx
+++ b/src/modules/dashboard/types/index.tsx
@@ -1,95 +1,88 @@
-import { Asesor } from '@/modules/asesor/types';
-import { ROLES, STATUS_CLIENT } from '@/modules/auth/types/enum';
-import { ReactNode } from 'react';
-import { FiBox, FiFile, FiHelpCircle, FiHome, FiMeh, FiSettings } from 'react-icons/fi';
+import {Asesor} from '@/modules/asesor/types';
+import {ROLES, STATUS_CLIENT} from '@/modules/auth/types/enum';
+import {ReactNode} from 'react';
+import {FiBox, FiFile, FiHelpCircle, FiHome, FiMeh, FiSettings} from 'react-icons/fi';
 
 export enum ROUTES_CONFIG {
-    ACTIVATE_ACCOUNT = '/activate-account',
+  ACTIVATE_ACCOUNT = '/activate-account',
 }
 export enum ROUTES_SIDEBAR {
-    DASHBOARD = '/dashboard',
-    INSTITUTIONS = '/dashboard/institutions',
-    INSTITUTION_INFO = '/dashboard/institution-info',
-    SETTINGS = '/dashboard/settings',
-    FILES = '/dashboard/files',
-    ASESOR = '/dashboard/asesor',
-    HELP = '/dashboard/help',
+  DASHBOARD = '/dashboard',
+  INSTITUTIONS = '/dashboard/institutions',
+  INSTITUTION_INFO = '/dashboard/institution-info',
+  SETTINGS = '/dashboard/settings',
+  FILES = '/dashboard/files',
+  ASESOR = '/dashboard/asesor',
 }
 export type Route = {
-    route: string;
-    name: string;
-    icon: ReactNode;
-    role: ROLES | 'all';
+  route: string;
+  name: string;
+  icon: ReactNode;
+  role: ROLES | 'all';
 };
 
 export const routesSidebarUp: Route[] = [
-    {
-        route: ROUTES_SIDEBAR.DASHBOARD,
-        name: 'Inicio',
-        icon: <FiHome />,
-        role: 'all',
-    },
-    {
-        route: ROUTES_SIDEBAR.ASESOR,
-        name: 'Asesor',
-        icon: <FiMeh />,
-        role: ROLES.INSTITUTION,
-    },
-    {
-        route: ROUTES_SIDEBAR.FILES,
-        name: 'Archivos',
-        icon: <FiFile />,
-        role: ROLES.INSTITUTION,
-    },
-    {
-        route: ROUTES_SIDEBAR.FILES,
-        name: 'Formatos',
-        icon: <FiFile />,
-        role: ROLES.ASSESOR,
-    },
-    {
-        route: ROUTES_SIDEBAR.INSTITUTION_INFO,
-        name: 'Institucion',
-        icon: <FiBox />,
-        role: ROLES.INSTITUTION,
-    },
-    {
-        route: ROUTES_SIDEBAR.INSTITUTIONS,
-        name: 'Instituciones',
-        icon: <FiFile />,
-        role: ROLES.ASSESOR,
-    },
+  {
+    route: ROUTES_SIDEBAR.DASHBOARD,
+    name: 'Inicio',
+    icon: <FiHome />,
+    role: 'all',
+  },
+  {
+    route: ROUTES_SIDEBAR.ASESOR,
+    name: 'Asesor',
+    icon: <FiMeh />,
+    role: ROLES.INSTITUTION,
+  },
+  {
+    route: ROUTES_SIDEBAR.FILES,
+    name: 'Archivos',
+    icon: <FiFile />,
+    role: ROLES.INSTITUTION,
+  },
+  {
+    route: ROUTES_SIDEBAR.FILES,
+    name: 'Formatos',
+    icon: <FiFile />,
+    role: ROLES.ASSESOR,
+  },
+  {
+    route: ROUTES_SIDEBAR.INSTITUTION_INFO,
+    name: 'Institucion',
+    icon: <FiBox />,
+    role: ROLES.INSTITUTION,
+  },
+  {
+    route: ROUTES_SIDEBAR.INSTITUTIONS,
+    name: 'Instituciones',
+    icon: <FiFile />,
+    role: ROLES.ASSESOR,
+  },
 ];
 
 export const routesSidebarDown: Route[] = [
-    {
-        route: ROUTES_SIDEBAR.SETTINGS,
-        name: 'Configuracion',
-        icon: <FiSettings />,
-        role: 'all',
-    },
-    {
-        route: ROUTES_SIDEBAR.HELP,
-        name: 'Ayuda',
-        icon: <FiHelpCircle />,
-        role: 'all',
-    },
+  {
+    route: ROUTES_SIDEBAR.SETTINGS,
+    name: 'Configuracion',
+    icon: <FiSettings />,
+    role: 'all',
+  },
 ];
 
 export type ClientInfoRes = {
-    id: number;
-    name: string;
-    givenName: string;
-    photo?: string;
-    surname: string;
-    status: STATUS_CLIENT;
-    email: string;
-    roles: Role[];
-    asesor?: Asesor;
+  id: number;
+  name: string;
+  givenName: string;
+  photo?: string;
+  surname: string;
+  status: STATUS_CLIENT;
+  email: string;
+  roles: Role[];
+  asesor?: Asesor;
 };
 
 export type Role = {
-    id: number;
-    roleName: ROLES;
-    description: string;
+  id: number;
+  roleName: ROLES;
+  description: string;
 };

--- a/src/modules/institution/services/actions.ts
+++ b/src/modules/institution/services/actions.ts
@@ -1,11 +1,16 @@
 'use server';
 
-import {createAllFormatService, createInstitutionService, updateLogoInstitutionService} from '.';
+import {
+  createAllFormatService,
+  createInstitutionService,
+  updateInfoInstitutionService,
+  updateLogoInstitutionService,
+} from '.';
 import {CommonActionState} from '@/modules/common/types/action';
-import {CreateInstitution, InstitutionLogo} from '../types';
+import {CreateInstitution, InstitutionInfo, InstitutionLogo} from '../types';
 import {BaseFormActionService} from '@/modules/common/services/action';
 import {UpdateDirectoryReqValidator} from '@/modules/files/types';
-import { CreateAllFormatReqValidator } from '@/modules/asesor/types';
+import {CreateAllFormatReqValidator} from '@/modules/asesor/types';
 
 export async function createInstitution(
   name?: string,
@@ -50,5 +55,17 @@ export async function updateLogoInstitution(
 }
 
 export async function createAllFormatForm(state: CommonActionState, payload: FormData) {
-  return await BaseFormActionService(state, payload, CreateAllFormatReqValidator, createAllFormatService); 
+  return await BaseFormActionService(
+    state,
+    payload,
+    CreateAllFormatReqValidator,
+    createAllFormatService
+  );
+}
+
+export async function updateInstitutionForm(
+  state: CommonActionState,
+  payload: FormData
+): Promise<CommonActionState> {
+  return await BaseFormActionService(state, payload, InstitutionInfo, updateInfoInstitutionService);
 }

--- a/src/modules/institution/services/index.ts
+++ b/src/modules/institution/services/index.ts
@@ -99,3 +99,7 @@ export async function updateInfoInstitutionService(
     };
   }
 }
+
+export async function getInstitutionByAsesorService(): Promise<InstitutionRes | null> {
+  return await apiSecureGet<InstitutionRes>(`/institution/asesor/get`);
+}

--- a/src/modules/institution/services/index.ts
+++ b/src/modules/institution/services/index.ts
@@ -1,5 +1,6 @@
 import {Institution, InstitutionRes} from '../types';
 import {
+  apiGet,
   apiPost,
   apiPut,
   apiSecureGet,
@@ -102,4 +103,14 @@ export async function updateInfoInstitutionService(
 
 export async function getInstitutionByAsesorService(): Promise<InstitutionRes | null> {
   return await apiSecureGet<InstitutionRes>(`/institution/asesor/get`);
+}
+
+export async function getClientByInstitutionService(id: number): Promise<number | null> {
+  try {
+    const response = await apiGet(`/institution-client/get/institution/${id}`);
+    return response.clientId ? parseInt(response.clientId, 10) : null;
+  } catch (error) {
+    console.error('Error fetching client:', error);
+    return null;
+  }
 }

--- a/src/modules/institution/services/index.ts
+++ b/src/modules/institution/services/index.ts
@@ -1,8 +1,14 @@
 import {Institution, InstitutionRes} from '../types';
-import {apiSecureGet, apiSecureMethodPostFile, apiSecurePost} from '@/modules/common/services';
-import {updateLogoInstitutionReq} from '../types/services';
+import {
+  apiPost,
+  apiPut,
+  apiSecureGet,
+  apiSecureMethodPostFile,
+  apiSecurePost,
+} from '@/modules/common/services';
+import {updateInfoInstitutionReq, updateLogoInstitutionReq} from '../types/services';
 import {CommonServiceRes} from '@/modules/common/types';
-import { CreateAllFormatReq, CreateAllFormatRes } from '@/modules/asesor/types';
+import {CreateAllFormatReq, CreateAllFormatRes} from '@/modules/asesor/types';
 
 export async function getServicesInstitution() {
   return await apiSecureGet(`/services`);
@@ -11,6 +17,7 @@ export async function getServicesInstitution() {
 export async function getInstitutionService(): Promise<InstitutionRes | null> {
   return await apiSecureGet<InstitutionRes>(`/institution`);
 }
+
 export async function createInstitutionService(
   institution: Institution
 ): Promise<Institution | null> {
@@ -22,6 +29,7 @@ export async function createInstitutionService(
     });
   return data;
 }
+
 export async function updateLogoInstitutionService(
   req: updateLogoInstitutionReq
 ): Promise<CommonServiceRes<boolean | null>> {
@@ -31,12 +39,12 @@ export async function updateLogoInstitutionService(
     const res = await apiSecureMethodPostFile(`/institution/logo/${req.id}`, formData);
     if (!res) {
       return {
-        errors: [['No se ha actualizado foto de institucion']],
+        errors: [['No se ha actualizado foto de institución']],
       };
     }
 
     return {
-      messages: ['Se ha actualizado foto de institucion'],
+      messages: ['Se ha actualizado foto de institución'],
     };
   } catch (error) {
     const e = error as Error;
@@ -54,18 +62,40 @@ export async function createAllFormatService(
   req: CreateAllFormatReq
 ): Promise<CommonServiceRes<CreateAllFormatRes | null>> {
   try {
-      const data = await apiSecurePost<CreateAllFormatRes>('/institution/create-all-formats', req);
-      if (!data) {
-          return { errors: [['No se ha podido crear todos los formatos']] };
-      }
-      return {
-          data,
-          messages: ['Los formatos han sido creados.'],
-      };
+    const data = await apiSecurePost<CreateAllFormatRes>('/institution/create-all-formats', req);
+    if (!data) {
+      return {errors: [['No se ha podido crear todos los formatos']]};
+    }
+    return {
+      data,
+      messages: ['Los formatos han sido creados.'],
+    };
   } catch (e) {
-      const error = e as Error;
+    const error = e as Error;
+    return {
+      errors: [[error.message]],
+    };
+  }
+}
+
+export async function updateInfoInstitutionService(
+  req: updateInfoInstitutionReq
+): Promise<CommonServiceRes<boolean | null>> {
+  try {
+    const res = await apiPut<boolean | null>(`/institution/${req.id}`, req);
+    console.log(req);
+    if (!res) {
       return {
-          errors: [[error.message]],
+        errors: [['No se ha actualizado la institución']],
       };
+    }
+    return {
+      messages: ['Se ha actualizado la informacion de la institución'],
+    };
+  } catch (error) {
+    const e = error as Error;
+    return {
+      errors: [[e.message]],
+    };
   }
 }

--- a/src/modules/institution/templates/asesor-institution.tsx
+++ b/src/modules/institution/templates/asesor-institution.tsx
@@ -6,20 +6,27 @@ export type Institution = {
   services?: any;
   asesorId: number;
   clients?: any;
+  photo?: any;
 };
 
 export type AsesorInstitutionProps = {
   institutions: Institution[];
 };
-
 export default function AsesorInstitution({institutions}: AsesorInstitutionProps) {
   return (
     <div className="p-8 bg-white mx-5 mb-5 rounded-xl h-screen">
       <div className="flex gap-5 grid-cols-6">
         {institutions.map(institution => (
-          <div className="flex flex-col justify-center  w-44 border-2 rounded-xl p-4">
+          <div
+            key={institution.id}
+            className="flex flex-col justify-center w-44 border-2 rounded-xl p-4"
+          >
             <h2>{institution.institutionName}</h2>
-            {institution.logo ? <img src={institution.logo} /> : <img src="/polife.png" />}
+            {institution.photo ? (
+              <img src={institution.photo} />
+            ) : (
+              <img src="/profile.png" alt="Default profile" />
+            )}
             <p>{institution.description}</p>
           </div>
         ))}

--- a/src/modules/institution/templates/asesor-institution.tsx
+++ b/src/modules/institution/templates/asesor-institution.tsx
@@ -22,11 +22,7 @@ export default function AsesorInstitution({institutions}: AsesorInstitutionProps
             className="flex flex-col justify-center w-44 border-2 rounded-xl p-4"
           >
             <h2>{institution.institutionName}</h2>
-            {institution.photo ? (
-              <img src={institution.photo} />
-            ) : (
-              <img src="/profile.png" alt="Default profile" />
-            )}
+            {institution.photo ? <img src={institution.photo} /> : <img src="/profile.png" />}
             <p>{institution.description}</p>
           </div>
         ))}

--- a/src/modules/institution/templates/asesor-institution.tsx
+++ b/src/modules/institution/templates/asesor-institution.tsx
@@ -1,0 +1,29 @@
+export type Institution = {
+  id: number;
+  institutionName: string;
+  logo: string;
+  description: string;
+  services?: any;
+  asesorId: number;
+  clients?: any;
+};
+
+export type AsesorInstitutionProps = {
+  institutions: Institution[];
+};
+
+export default function AsesorInstitution({institutions}: AsesorInstitutionProps) {
+  return (
+    <div className="p-8 bg-white mx-5 mb-5 rounded-xl h-screen">
+      <div className="flex gap-5 grid-cols-6">
+        {institutions.map(institution => (
+          <div className="flex flex-col justify-center  w-44 border-2 rounded-xl p-4">
+            <h2>{institution.institutionName}</h2>
+            {institution.logo ? <img src={institution.logo} /> : <img src="/polife.png" />}
+            <p>{institution.description}</p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/modules/institution/templates/information.tsx
+++ b/src/modules/institution/templates/information.tsx
@@ -5,39 +5,39 @@ import {Input} from '@/modules/common/components/input';
 import {SubmitButton} from '@/modules/common/components/submit-button';
 import {Textarea} from '@/modules/common/components/text-area';
 import LogoInstitution from '../components/logo-institution';
-import Services from '../components/services-institution';
-import {useAtom} from 'jotai';
-import {institutionStorage} from '../context';
 import {InstitutionRes} from '../types';
+import {useRouter} from 'next/navigation';
+import {useFormState} from 'react-dom';
+import {useFormResponse} from '@/modules/common/hooks/use-form-response';
+import {updateInstitutionForm} from '../services/actions';
 
 export type InformationInstitutionProps = {
   institution: InstitutionRes;
 };
 
 export default function InformationInstitution(props: InformationInstitutionProps) {
-  /*
-    const [response, dispatch] = useFormState(, {
-        message: null,
-        errors: {},
-    });
+  const router = useRouter();
+  const [response, dispatch] = useFormState(updateInstitutionForm, {
+    messages: [],
+    errors: [],
+  });
 
-    useEffect(() => {
-        if (response.errors) {
-            return;
-        }
+  useFormResponse({
+    response,
+    onEnd: () => {
+      router.refresh();
+    },
+  });
 
-        toast.success(response?.message);
-    }, [response]);
+  const handleSubmit = (formData: FormData) => {
+    formData.set('id', props.institution.id.toString());
+    console.log('Form Data:', Array.from(formData.entries()));
+    dispatch(formData);
+  };
 
-    const handleSubmit = (formData: FormData) => {
-        formData.set("id", props.institution.id.toString());
-        dispatch(formData);
-    };
-*/
-  const [institution, setInstitution] = useAtom(institutionStorage);
   return (
     <section className="flex flex-col m-4 p-4 bg-white shadow-md rounded-lg ">
-      <form className="flex flex-col gap-4">
+      <form className="flex flex-col gap-4" action={handleSubmit}>
         <div className="flex flex-col gap-[10px]">
           <h1 className="text-xl pt-1">Informacion</h1>
           <hr className="w-full border-t" />

--- a/src/modules/institution/types/index.ts
+++ b/src/modules/institution/types/index.ts
@@ -46,3 +46,9 @@ export enum ROUTES_INSTITUTION {
   INSTITUTION_SERVICES = '/dashboard/institution-info/services',
   INSTITUTION_USERS = '/dashboard/institution-info/users',
 }
+
+export const InstitutionInfo = z.object({
+  id: z.number({coerce: true}),
+  institutionName: z.string(),
+  description: z.string(),
+});

--- a/src/modules/institution/types/services.ts
+++ b/src/modules/institution/types/services.ts
@@ -2,3 +2,9 @@ export type updateLogoInstitutionReq = {
   id: number;
   logo: File;
 };
+
+export type updateInfoInstitutionReq = {
+  id: number;
+  institutionName: string;
+  description: string;
+};

--- a/src/modules/settings/pages/integrations.tsx
+++ b/src/modules/settings/pages/integrations.tsx
@@ -1,3 +1,0 @@
-export default function Integrations() {
-  return <p>Integraciones</p>;
-}

--- a/src/modules/settings/pages/security.tsx
+++ b/src/modules/settings/pages/security.tsx
@@ -1,3 +1,0 @@
-export default function Security() {
-  return <p>Seguridad</p>;
-}

--- a/src/modules/settings/types/index.tsx
+++ b/src/modules/settings/types/index.tsx
@@ -2,9 +2,7 @@ import {ROUTES_SIDEBAR} from '@/modules/dashboard/types';
 import {z} from 'zod';
 
 export enum ROUTES_SETTINGS {
-  INTEGRATIONS = '/dashboard/settings/integrations',
   NOTIFICATIONS = '/dashboard/settings/notifications',
-  SECURITY = '/dashboard/settings/security',
 }
 export type route = {
   route: string;
@@ -35,16 +33,8 @@ export const routesSettings = [
     name: 'Detalles generales',
   },
   {
-    route: ROUTES_SETTINGS.INTEGRATIONS,
-    name: 'Integraciones',
-  },
-  {
     route: ROUTES_SETTINGS.NOTIFICATIONS,
     name: 'Notificaciones',
-  },
-  {
-    route: ROUTES_SETTINGS.SECURITY,
-    name: 'Seguridad',
   },
 ];
 


### PR DESCRIPTION
# View Institutions in asesor and other changes

## Description
- Ahora el asesor puede ver las instituciones que tiene, esto es, en `instituciones` del `side bar`
![imagen](https://github.com/user-attachments/assets/c4398f64-bf9c-4db6-8a3d-4347d07e8ba2)

- Se eliminan los accesos que no se están usando como 
-- Help
-- Security
-- Integrations
- El botón de actualizar institución, está funcionando

## Test
Se hizo el test probándolo en el navegador

## Checklist:
- [x]  My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules